### PR TITLE
add support sending images "as a document"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ if __name__ == "__main__":
   * password: j8XfG9ZDT5ZZrWTzw62q
 * Docs (you can submit requests from web ui): http://127.0.0.1:8000/docs#/
 * Redoc: http://127.0.0.1:8000/redoc
-* Telegram bot is ready to classify ants & bees, but you have to send files "as a photo"
+* Telegram bot is ready to classify ants & bees, you have to send files "as a photo" or "as a file"
 
 ## Telegram bot quick howto
 

--- a/example/tgbot.py
+++ b/example/tgbot.py
@@ -14,6 +14,21 @@ async def start(chat: Chat, match):
     return chat.reply("Send me photo of ant or bee.")
 
 
+async def process_image(binary_data, chat_to_reply: Chat):
+    # Convert binary data to numpy.ndarray image
+    image = imageio.imread(binary_data)
+
+    # Do the magic
+    tag = await model.predict.call(image)
+
+    # Simple text response
+    await chat_to_reply.reply(f"I think this is {tag} ...")
+
+    # Or image response
+    with open(f"{tag}.jpg", "rb") as f:
+        await chat_to_reply.send_photo(f, caption=f"... the {tag} like this one!")
+
+
 @bot.handle("photo")
 async def handle_photo(chat: Chat, photos):
     # Get image binary data
@@ -21,18 +36,17 @@ async def handle_photo(chat: Chat, photos):
     resp = await bot.download_file(meta["file_path"])
     data = await resp.read()
 
-    # Convert binary data to numpy.ndarray image
-    image = imageio.imread(data)
+    await process_image(data, chat)
 
-    # Do the magic
-    tag = await model.predict.call(image)
 
-    # Simple text response
-    await chat.reply(f"I think this is {tag} ...")
+@bot.handle("document")
+async def handle_document(chat: Chat, document):
+    # Get image binary data
+    meta = await bot.get_file(document["file_id"])
+    resp = await bot.download_file(meta["file_path"])
+    data = await resp.read()
 
-    # Or image response
-    with open(f"{tag}.jpg", "rb") as f:
-        await chat.send_photo(f, caption=f"... the {tag} like this one!")
+    await process_image(data, chat)
 
 
 @bot.command(r"/square (.+)")

--- a/example/tgbot.py
+++ b/example/tgbot.py
@@ -26,7 +26,7 @@ async def process_image(binary_data, chat_to_reply: Chat):
 
     # Or image response
     with open(f"{tag}.jpg", "rb") as f:
-        await chat_to_reply.send_photo(f, caption=f"... the {tag} like this one!")
+        await chat_to_reply.send_photo(f, caption=f"The {tag} like this one!")
 
 
 @bot.handle("photo")


### PR DESCRIPTION
Telegram compresses images  sent as photos ant applies jpeg compression for them. This can lead to different predictions obtained through the web interface and through the bot. This PR adds the ability to send files to model through the bot without compression.