### PR TITLE
Dockerfile fix

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -17,8 +17,8 @@ ENV PYTHONPATH=/src
 
 WORKDIR /src
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+COPY requirements/requirements.txt .
+RUN pip install -r requirements.txt --ignore-installed PyYAML
 
 RUN wget https://www.dropbox.com/s/sl0fbzeo2fgbmum/classifier-190915.tar && \
     tar -xvf classifier-190915.tar && \


### PR DESCRIPTION
1. `requirements.txt` is not in the `requirements` folder
2. When installing requirements in docker build I've faced next problem:
![pyyaml_exc](https://user-images.githubusercontent.com/26285240/88544590-4eef6a00-d022-11ea-8272-b1cc8c5fcec9.png)
In [stackoverflow](https://stackoverflow.com/questions/49911550/how-to-upgrade-disutils-package-pyyaml) were proposed to add `--ignore-installed PyYAML` flag to overcome this problem