### PR TITLE
fix yarl version in requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
 fastapi[all]>=0.38.1,<1.0.0
 aio-pika==6.1.1
+yarl==1.4.2


### PR DESCRIPTION
[yarl](https://github.com/aio-libs/yarl) updated it's version (to 1.5.0) 2 days ago.
This version causes problems with aio_pika (`consume` function throws `ConnectionError`)
I suggest to fix `yarl` version to `1.4.2`. With this version service works fine.